### PR TITLE
Fix linux-CIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# macOS
+.DS_Store

--- a/linux/setup_sound.sh
+++ b/linux/setup_sound.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e
 
+sudo apt update
 sudo apt install -y pulseaudio libportaudio2 dbus-x11
 dbus-launch pulseaudio --start


### PR DESCRIPTION
GitHub CIs on Linux started failing a couple of days ago. Adding `sudo apt update` fixes it. Would you like to add it directly here?

```
Run ./sound-ci-helpers/auto.sh
Linux (linux-gnu)

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  gstreamer1.0-plugins-base libasound2-plugins libasyncns0 libcdparanoia0
  libflac8 libgstreamer-plugins-base1.0-0 libjack-jackd2-0 libopus0
  liborc-0.4-0 libpulse0 libpulsedsp libsamplerate0 libsnapd-glib1 libsndfile1
  libsoxr0 libspeexdsp1 libtheora0 libvisual-0.4-0 libvorbisenc2
  libwebrtc-audio-processing1 pulseaudio-utils rtkit
Suggested packages:
  gvfs libvisual-0.4-plugins jackd2 opus-tools pavumeter pavucontrol paman
  paprefs ubuntu-sounds avahi-daemon
The following NEW packages will be installed:
  dbus-x11 gstreamer1.0-plugins-base libasound2-plugins libasyncns0
  libcdparanoia0 libflac8 libgstreamer-plugins-base1.0-0 libjack-jackd2-0
  libopus0 liborc-0.4-0 libportaudio2 libpulse0 libpulsedsp libsamplerate0
  libsnapd-glib1 libsndfile1 libsoxr0 libspeexdsp1 libtheora0 libvisual-0.4-0
  libvorbisenc2 libwebrtc-audio-processing1 pulseaudio pulseaudio-utils rtkit
0 upgraded, 25 newly installed, 0 to remove and 13 not upgraded.
Need to get 5421 kB of archives.
After this operation, 20.5 MB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 liborc-0.4-0 amd64 1:0.4.31-1 [188 kB]
Err:2 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.16.3-0ubuntu1
  404  Not Found [IP: 40.81.13.82 80]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libasyncns0 amd64 0.8-6 [12.1 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libflac8 amd64 1.3.3-1build1 [103 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvorbisenc2 amd64 1.3.6-2ubuntu1 [70.7 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libsndfile1 amd64 1.0.28-7ubuntu0.1 [170 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libpulse0 amd64 1:13.99.1-1ubuntu3.13 [262 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libsnapd-glib1 amd64 1.58-0ubuntu0.20.04.0 [90.1 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsoxr0 amd64 0.1.3-2build1 [78.0 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libspeexdsp1 amd64 1.2~rc1.2-1.1ubuntu1.20.04.1 [40.4 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libwebrtc-audio-processing1 amd64 0.3.1-0ubuntu3 [263 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsamplerate0 amd64 0.1.9-2 [939 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libjack-jackd2-0 amd64 1.9.12~dfsg-2ubuntu2 [267 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libasound2-plugins amd64 1.2.2-1ubuntu1 [66.0 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libpulsedsp amd64 1:13.99.1-1ubuntu3.13 [21.7 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 pulseaudio-utils amd64 1:13.99.1-1ubuntu3.13 [55.0 kB]
Get:17 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 pulseaudio amd64 1:13.99.1-1ubuntu3.13 [814 kB]
Get:18 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 dbus-x11 amd64 1.12.16-2ubuntu2.2 [22.6 kB]
Get:19 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libcdparanoia0 amd64 3.10.2+debian-13 [46.7 kB]
Get:20 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libopus0 amd64 1.3.1-0ubuntu1 [191 kB]
Get:21 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libtheora0 amd64 1.1.1+dfsg.1-15ubuntu2 [162 kB]
Get:22 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvisual-0.4-0 amd64 0.4.0-17 [99.8 kB]
Err:23 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 gstreamer1.0-plugins-base amd64 1.16.3-0ubuntu1
  404  Not Found [IP: 40.81.13.82 80]
Get:24 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libportaudio2 amd64 19.6.0-1build1 [65.4 kB]
Get:25 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 rtkit amd64 0.12-4 [34.1 kB]
Fetched 4062 kB in 2s (1861 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-0_1.16.3-0ubuntu1_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/g/gst-plugins-base1.0/gstreamer1.0-plugins-base_1.16.3-0ubuntu1_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```