### PR TITLE
Support Ubuntu 22.04

### DIFF
--- a/linux/setup_sound.sh
+++ b/linux/setup_sound.sh
@@ -2,4 +2,4 @@
 
 sudo apt update
 sudo apt install -y pulseaudio libportaudio2 dbus-x11 libasound-dev
-dbus-launch pulseaudio --start
+systemctl --user start pulseaudio.socket


### PR DESCRIPTION
This PR updates the Linux script to work with Ubuntu 22.04. In my testing, `pulseaudio --start` or `pulseaudio -D --start` works on Ubuntu 20.04 but doesn't do anything on Ubuntu 22.04. When I start it with `sytemctl`, it works fine.