### PR TITLE
Windows updates to get vbcable working in latest windows runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04-arm, ubuntu-24.04, ubuntu-22.04, windows-2022, windows-2019, macos-15, macos-14, macos-13]
+        os: [ubuntu-24.04-arm, ubuntu-24.04, ubuntu-22.04, windows-2025, windows-2022, macos-15, macos-14, macos-13]
         python: ['3.13', '3.10']
     defaults:
       run:
@@ -31,11 +31,9 @@ jobs:
       - run: pip install sounddevice
       - run: python -m sounddevice
       - run: |
-          set -xeo pipefail
-          python -m sounddevice | grep "[82] out"
-        name: Check that there is some output device
-      - run: sleep 10
-      - run: |
-          set -xeo pipefail
-          python -m sounddevice | grep "[82] out"
-        name: Check that there is some output device after sleep
+          output=$(python -m sounddevice --list-devices)
+          if [ -z "$output" ]; then
+            echo "Error: sounddevice --list-devices returned no output"
+            exit 1
+          fi
+          echo "$output"


### PR DESCRIPTION
Hello! I rewrote the windows/setup_sound.ps1 script to be able to get/list audio devices in SDL3 tests.

Changes include:

- New setup_sound.ps1 script
- Added windows-2025, removed windows-2019 (2019 support was removed very recently)
- Switched to VBCABLE_Driver_Pack45 to get the needed win10 inf file
- Changed the approach for testing device output to not rely on specific device number.

I'm using these changes in an [SDL3 bindings project](https://github.com/holepunchto/bare-sdl/pull/33) that you can check out for proof it works.

The ps1 script changes are pretty substantial so I'm happy to make changes if needed; I'm worried about having changed something needed for your use case.
